### PR TITLE
build: Unbreak YAML syntax in GH-hsoted runner; clean up dev requirements

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -64,11 +64,10 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install Required Python Dependencies
+        env:
+          PIP_SRC: ${{ runner.temp }}
         run: |
-            pip install -r requirements/pip.txt
-            pip install -r requirements/edx/development.txt --src ${{ runner.temp }}
-#            edx-platform installs some Python projects from within the edx-platform repo itself.
-            pip install -e .
+            make dev-requirements
             pip install "django~=${{ matrix.django-version }}.0"
 
       - name: Setup and run tests
@@ -106,8 +105,9 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install Required Python Dependencies
+        env:
+          PIP_SRC: ${{ runner.temp }}
         run: |
-            pip install -r requirements/pip.txt
             make dev-requirements
             pip install "django~=${{ matrix.django-version }}.0"
 


### PR DESCRIPTION
The comment starting at column zero made this Action unparseable. But the comment can also just be removed entirely by using the new `dev-requirements` target, which after PR #31080/commit 2edbdcf7f4 now also installs pip and edxapp.

I'm not exactly sure why `--src` is being specified here (is this a global package installation, and therefore the editable deps would be installed in the working dir?) but it can be specified even with pip-sync via `PIP_SRC`. I also added it to the verify job since it should probably be there as well.
